### PR TITLE
Improve merge functions to incorporate fields and fix query parsing functions and add in boost scoring

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -47,3 +47,9 @@ def decode(bytestream):
             numbers.append(n)
             n = 0
     return numbers
+
+def check_and_decode(input):
+    if isinstance(input, list):
+        return input
+    else:
+        return decode(input)

--- a/index.py
+++ b/index.py
@@ -42,7 +42,7 @@ def comparator(arr1, arr2):
             return -1
         elif arr2[1][1] == Field.COURT:
             return 1
-        elif arr1[1][1] == Field.CONTENT:
+        elif arr1[1][1] == Field.COURT:
             return -1
     else:
         return 0
@@ -346,26 +346,27 @@ def build_index(in_dir, out_dict, out_postings):
     vsm.build()
     vsm.write()
 
-input_directory = output_file_dictionary = output_file_postings = None
+if __name__ == "__main__":
+    input_directory = output_file_dictionary = output_file_postings = None
 
-try:
-    opts, args = getopt.getopt(sys.argv[1:], 'i:d:p:')
-except getopt.GetoptError:
-    usage()
-    sys.exit(2)
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'i:d:p:')
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
 
-for o, a in opts:
-    if o == '-i': # input directory
-        input_directory = a
-    elif o == '-d': # dictionary file
-        output_file_dictionary = a
-    elif o == '-p': # postings file
-        output_file_postings = a
-    else:
-        assert False, "unhandled option"
+    for o, a in opts:
+        if o == '-i': # input directory
+            input_directory = a
+        elif o == '-d': # dictionary file
+            output_file_dictionary = a
+        elif o == '-p': # postings file
+            output_file_postings = a
+        else:
+            assert False, "unhandled option"
 
-if input_directory == None or output_file_postings == None or output_file_dictionary == None:
-    usage()
-    sys.exit(2)
+    if input_directory == None or output_file_postings == None or output_file_dictionary == None:
+        usage()
+        sys.exit(2)
 
-build_index(input_directory, output_file_dictionary, output_file_postings)
+    build_index(input_directory, output_file_dictionary, output_file_postings)

--- a/index.py
+++ b/index.py
@@ -42,7 +42,7 @@ def comparator(arr1, arr2):
             return -1
         elif arr2[1][1] == Field.COURT:
             return 1
-        elif arr1[1][1] == Field.COURT:
+        elif arr1[1][1] == Field.CONTENT:
             return -1
     else:
         return 0

--- a/search.py
+++ b/search.py
@@ -94,7 +94,7 @@ def cosine_score(tokens_arr):
         # We will calculate its weight in Step 3
         # This is nicely reflected in the term's PostingList
         # Only documents with Postings of this term will have non-zero score contributions
-        posting_list = []
+        posting_list = None
         if " " in term:
             posting_list_object = perform_phrase_query(term)
             if posting_list_object is not None:

--- a/search.py
+++ b/search.py
@@ -394,11 +394,12 @@ def split_query(query):
             else:
                 start_index = current_index + 1
                 is_in_phrase = True
-                is_boolean_query = True
         elif current_char == " ":
             # Append the word if not parsing part of phrase
             if not is_in_phrase:
                 terms.append(query[start_index:current_index])
+                if (query[start_index:current_index] == AND_KEYWORD):
+                    is_boolean_query = True
                 start_index = current_index + 1
         current_index += 1
 

--- a/search.py
+++ b/search.py
@@ -352,6 +352,7 @@ def parse_boolean_query(terms):
     return get_ranking_for_boolean_query(res_posting_list)
 
 def parse_free_text_query(terms):
+    # TODO: See below (delete once done)
     #Expected to add query expansion, after process(query) is done
     #query = query_expansion(process(query))
     res = cosine_score(terms)

--- a/search.py
+++ b/search.py
@@ -390,6 +390,31 @@ def split_query(query):
     return [term for term in terms if term], is_boolean_query
 
 def query_expansion(query):
+    #Split the query into words
+    #Remove stop words
+    #Find the synonyms of each word and append them to a set, since some of the synonyms might be repetitive
+    #Add the set of synonyms to list of extended query words
+    #Convert the extended query list to extende query string
+    #Return the string
+
+    query_words = query.split()
+    stop_words = set(stopwords.words('english'))
+    query_words = [word for word in query_words if not word in stop_words]
+    expanded_query = []
+    for word in query_words:
+        expanded_query.append(word)
+        syn_set = set()
+        for s in wordnet.synsets(word):
+            for l in s.lemmas():
+                syn_set.add(l.name())
+        expanded_query.extend(syn_set)
+
+    new_query = ' '.join([str(word) for word.lower() in expanded_query])
+
+    return new_query
+# Below are the code provided in the original Homework search.py file, with edits to run_search to use our implementation
+
+def usage():
     print("usage: " + sys.argv[0] + " -d dictionary-file -p postings-file -q file-of-queries -o output-file-of-results")
 
 def run_search(dict_file, postings_file, queries_file, results_file):

--- a/search.py
+++ b/search.py
@@ -36,7 +36,7 @@ def filter_punctuations(s):
     Replaces certain punctuations from Strings with space, to be removed later on
     Takes in String s and returns the processed version of it
     """
-    punctuations = '''!?-;:"\\,./#$%^&<>[]{}*_~()'''
+    punctuations = '''!?-;:\\,./#$%^&<>[]{}*_~()'''
     filtered_term = ""
     for character in s:
         if character in punctuations:


### PR DESCRIPTION
3 major changes here for review, along with minor fixes

NOTE: My dictionary is being built now, so i havent really tested this. I expect to find bugs which I will fix, but the general logic should be there. 

1. Allow the merging of posting lists to recognize fields forr boolean queries (See `merge_posting_lists`)

2. Add in an additional `split_query` function to tidy up how we parse queries and to extract phrases and terms properly and fixed boolean query handling in general

3. Implemented boost scoring for both boolean and free text queries. See `boost_score_based_on_field` and `get_ranking_for_boolean_query`

For free text queries, I also boosted the score of the document by a lot if the query contains the document id of said document

**Minor fixes**
1. `find_term` now returns a PostingList object for a more consistent api, though now must remember to decode the positions of the `Posting` by yourself
2. Clean up `process` and `filter_punctuations` (the latter to shorten runtime)